### PR TITLE
Release/1.0.8

### DIFF
--- a/Gateway/Response/VaultMarketplacerRegistry.php
+++ b/Gateway/Response/VaultMarketplacerRegistry.php
@@ -14,6 +14,7 @@ use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Payment\Gateway\Response\HandlerInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory;
 use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
+use Magento\Vault\Model\PaymentTokenFactory;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
 use PayPal\Braintree\Gateway\Config\Config;
 use PayPal\Braintree\Gateway\Helper\SubjectReader;
@@ -28,7 +29,7 @@ class VaultMarketplacerRegistry extends Handler implements HandlerInterface
     private $vaultCustomerRegistry;
 
     public function __construct(
-        PaymentTokenFactoryInterface $paymentTokenFactory,
+        PaymentTokenFactory $paymentTokenFactory,
         OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory,
         Config $config,
         SubjectReader $subjectReader,

--- a/etc/module_info.xml
+++ b/etc/module_info.xml
@@ -2,6 +2,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Marketplacer_Base:etc/module_info.xsd">
     <module name="Marketplacer_SellerShipping">
-        <version>1.0.7</version>
+        <version>1.0.8</version>
     </module>
 </config>


### PR DESCRIPTION
The braintree payment fix applied only works from Adobe Commerce 2.4.8 which is in beta. This PR made this fix to be compatible to older versions.


## Checklist

- [ ] Deployed to an environment
- [ ] PR has appropriate labels added (needs-testing, etc.)
- [ ] Authentication is on point (you are who you say you are)
- [ ] Authorisation is on point (you are allowed to access this)
- [ ] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [ ] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [ ] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [ ] Any schema changes have been notified to the data platform team in #data-change-notifications on slack.
- [ ] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [ ] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Confluence Docs, Postman Collection, Lucid Charts, and your PM knows what's up.

**See:** https://marketplacer.atlassian.net/wiki/spaces/PT/pages/46170530/System+Acquisition+and+Development+Policy
**See:** https://marketplacer.atlassian.net/wiki/spaces/PT/pages/14156267/threat-modelling
